### PR TITLE
Address issue with comment handling in the splitter

### DIFF
--- a/lib/css_splitter/splitter.rb
+++ b/lib/css_splitter/splitter.rb
@@ -95,7 +95,7 @@ module CssSplitter
     private
 
       def self.strip_comments(s)
-        s.gsub(/\/\/.*$/, "").gsub(/\/\*.*?\*\//, "")
+        s.gsub(/\/\*.*?\*\//m, "")
       end
 
   end

--- a/test/unit/splitter_test.rb
+++ b/test/unit/splitter_test.rb
@@ -9,4 +9,24 @@ class CssSplitterTest < ActiveSupport::TestCase
     assert_equal CssSplitter::Splitter.count_selectors_of_rule('foo { color: baz; }'), 1
     assert_equal CssSplitter::Splitter.count_selectors_of_rule('foo, bar { color: baz; }'), 2
   end
+
+  test '#split_string_into_rules' do
+    simple = "a{foo:bar;}b{baz:qux;}"
+    assert_equal ["a{foo:bar;}", "b{baz:qux;}"], CssSplitter::Splitter.split_string_into_rules(simple)
+  end
+
+  test '#split_string_into_rules for single line comments' do
+    multi_line = "a{foo:bar;} /* comment p{bar:foo;} */ b{baz:qux;}"
+    assert_equal ["a{foo:bar;}", "  b{baz:qux;}"], CssSplitter::Splitter.split_string_into_rules(multi_line)
+  end
+
+  test '#split_string_into_rules for multiline comments' do
+    multi_line = "a{foo:bar;}\n/*\nMultiline comment p{bar:foo;}\n*/\nb{baz:qux;}"
+    assert_equal ["a{foo:bar;}", "\n\nb{baz:qux;}"], CssSplitter::Splitter.split_string_into_rules(multi_line)
+  end
+
+  test '#split_string_into_rules for strings with protocol independent urls' do
+    simple = "a{foo:url(//assets.server.com);}b{bar:url(//assets/server.com);}"
+    assert_equal ["a{foo:url(//assets.server.com);}", "b{bar:url(//assets/server.com);}"], CssSplitter::Splitter.split_string_into_rules(simple)
+  end
 end


### PR DESCRIPTION
This pull request will fix an issue that destroys CSS files that contain protocol independent urls (for example: `background-image: url(//assets.myserver.com/asset.png)`).

It also addresses the issue of wrongfully parsed multiline comments.

Not that this changes the current behavior as it will no longer remove `//` comments. This should be the correct behavior since `//` is not a valid CSS comment.
