### PR TITLE
Properly handle media query closing braces

### DIFF
--- a/lib/css_splitter/splitter.rb
+++ b/lib/css_splitter/splitter.rb
@@ -39,12 +39,13 @@ module CssSplitter
         rule_selectors_count = count_selectors_of_rule rule
         selectors_count += rule_selectors_count
 
+        if rule =~ /^\s*}$/
+          current_media = nil
+          # skip the line if the close bracket is the first rule for the new file
+          next if first_hit
+        end
+
         if selector_range.cover? selectors_count # add rule to current output if within selector_range
-          if rule =~ /^\s*}$/
-            current_media = nil
-            # skip the line if the close bracket is the first rule for the new file
-            next if first_hit
-          end
           if media_part
             output << media_part
           elsif first_hit && current_media
@@ -67,7 +68,8 @@ module CssSplitter
 
     # count selectors of one individual CSS rule
     def self.count_selectors_of_rule(rule)
-      strip_comments(rule).partition(/\{/).first.scan(/,/).count.to_i + 1
+      parts = strip_comments(rule).partition(/\{/)
+      parts.second.empty? ? 0 : parts.first.scan(/,/).count.to_i + 1
     end
 
 


### PR DESCRIPTION
I noticed media query blocks weren't properly being handled when they occur entirely before the split. For instance, for the following CSS:

``` css
@media print {
  .media-rule { color: black; }
}
.a0 { color: black; }
.a1 { color: black; }
/* ... */
.a4093 { color: black; }
.first-after-split { color: black; }
```

We would expect that the split would just contain this:

``` css
.first-after-split { color: black; }
```

However, without this fix, it ends up containing this:

``` css
@media print {
  .a4093 { color: black; }
  .first-after-split { color: black; }
}
```

This was caused by two issues:
- `extract_part` only checked for the closing brace under the `if selector_range.cover? selectors_count` condition. Because of this, it never knew that the media block had closed. This fix moves that check outside of that condition.
- `count_selectors_of_rule` incorrectly counted the closing brace of the media query as a selector. This fix takes this into account.
