### PR TITLE
Updated helper to fix ?body=1 issue with Sprockets in development mode

### DIFF
--- a/app/helpers/css_splitter/application_helper.rb
+++ b/app/helpers/css_splitter/application_helper.rb
@@ -1,20 +1,37 @@
 module CssSplitter
   module ApplicationHelper
     def split_stylesheet_link_tag(*sources)
-      options     = sources.extract_options!
-      split_count = options.delete(:split_count) || 2
+      if Rails.env != 'development'
+        split_stylesheet_link_tag(sources)
+      else
+        options     = sources.
+                      extract_options!.
+                      merge!({
+                        href: "/assets/#{ sources.first }.css",
+                        rel: :stylesheet
+                      })
+        split_count = options.delete(:split_count) || 2
 
-      sources.map do |source|
-        split_sources = (2..split_count).map { |index| "#{source}_split#{index}" }
-        split_sources << options
+        sources.map do |source|
+          split_sources = (2..split_count).map { |index| "#{ source }_split#{ index }" }
 
-        [
-          stylesheet_link_tag(source, options),
-          "<!--[if lte IE 9]>",
-          stylesheet_link_tag(*split_sources),
-          "<![endif]-->"
-        ]
-      end.flatten.join("\n").html_safe
+          lines = [
+            content_tag(:link, nil, options),
+            stylesheet_link_tag(source, options),
+            "<!--[if lte IE 9]>"
+          ]
+
+          split_sources.each do |split_source|
+            lines << content_tag(
+                       :link,
+                       nil,
+                       options.merge({ href: "/assets/#{ split_source }.css" })
+                     )
+          end
+          lines << "<![endif]-->"
+          lines
+        end.flatten.join("\n").html_safe
+      end
     end
   end
 end


### PR DESCRIPTION
in a development environment this helper does not work (e.g. the file is not found or empty) due to Sprockets' ?body=1 being tacked onto the file path.
