### PR TITLE
Fixing ?body=1 issue with Sprockets in development environment

### DIFF
--- a/app/helpers/css_splitter/application_helper.rb
+++ b/app/helpers/css_splitter/application_helper.rb
@@ -3,6 +3,7 @@ module CssSplitter
     def split_stylesheet_link_tag(*sources)
       options     = sources.extract_options!
       split_count = options.delete(:split_count) || 2
+
       sources.map do |source|
         split_sources = (2..split_count).map { |index| "#{ source }_split#{ index }" }
 


### PR DESCRIPTION
File would not be found with ?body=1 tacked on by Sprockets in development mode.
