### PR TITLE
Modify Gemfile to install correct debugger for development.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem "pry-debugger", platforms: :ruby_19
-  gem 'pry-byebug', platforms: [:ruby_20, :ruby_21]
+  gem 'pry-byebug'
 end
 
 gem "rails"


### PR DESCRIPTION
I had some trouble setting up local env, due to gem 'debugger'.

I've added conditionally 'pry-byebug' for ruby 2.0 +

Since ruby 1.9.3 is not developed anymore removing debugger at all might be good idea.
