### PR TITLE
allow disabling of ie hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Basically, CssSplitter is registering a new Sprockets bundle processor that look
 
 If you have more questions about how it works, look at the code or contact us.
 
+## Disabling IE conditional comments
+
+You can pass `ie_hack: false` as an option to `split_stylesheet_link_tag` if you don't want the IE conditional comments generated.  This can be useful if you need to embed all of the split stylesheets inside an IE conditional comment.
+
 ## Gotchas
 
 #### Differences from previous versions

--- a/app/helpers/css_splitter/application_helper.rb
+++ b/app/helpers/css_splitter/application_helper.rb
@@ -3,6 +3,7 @@ module CssSplitter
     def split_stylesheet_link_tag(*sources)
       options     = sources.extract_options!
       split_count = options.delete(:split_count) || 2
+      ie_hack     = options.delete(:ie_hack) != false
 
       sources.map do |source|
         split_sources = (2..split_count).map { |index| "#{source}_split#{index}" }
@@ -14,10 +15,10 @@ module CssSplitter
 
         [
           stylesheet_link_tag(source, options),
-          "<!--[if lte IE 9]>",
+          ("<!--[if lte IE 9]>" if ie_hack),
           stylesheet_link_tag(*split_sources),
-          "<![endif]-->"
-        ]
+          ("<![endif]-->" if ie_hack)
+        ].compact
       end.flatten.join("\n").html_safe
     end
   end


### PR DESCRIPTION
I have a situation in which I want to embed all of the stylesheets inside an IE conditional comment.  So I'd like to offer this option to disable the automatically generated conditional comments.  Thanks for this cool gem!