### PR TITLE
Fix ApplicationHelper tests to play well with rails 4.2

### DIFF
--- a/test/unit/helpers/css_splitter/application_helper_test.rb
+++ b/test/unit/helpers/css_splitter/application_helper_test.rb
@@ -5,17 +5,17 @@ module CssSplitter
 
     test "should work w/out options" do
       output = split_stylesheet_link_tag("too_big_stylesheet")
-      assert_equal "<link href=\"/stylesheets/too_big_stylesheet.css\" media=\"screen\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"screen\" rel=\"stylesheet\" />\n<![endif]-->", output
+      assert_equal "<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet.css\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split2.css\" />\n<![endif]-->", output
     end
 
     test "should work with options and multiple stylesheets" do
       output = split_stylesheet_link_tag("too_big_stylesheet", "foo", media: "print")
-      assert_equal "<link href=\"/stylesheets/too_big_stylesheet.css\" media=\"print\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"print\" rel=\"stylesheet\" />\n<![endif]-->\n<link href=\"/stylesheets/foo.css\" media=\"print\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link href=\"/stylesheets/foo_split2.css\" media=\"print\" rel=\"stylesheet\" />\n<![endif]-->", output
+      assert_equal "<link rel=\"stylesheet\" media=\"print\" href=\"/stylesheets/too_big_stylesheet.css\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"print\" href=\"/stylesheets/too_big_stylesheet_split2.css\" />\n<![endif]-->\n<link rel=\"stylesheet\" media=\"print\" href=\"/stylesheets/foo.css\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"print\" href=\"/stylesheets/foo_split2.css\" />\n<![endif]-->", output
     end
 
     test "should work with split_count option" do
       output = split_stylesheet_link_tag("too_big_stylesheet", split_count: 3)
-      assert_equal "<link href=\"/stylesheets/too_big_stylesheet.css\" media=\"screen\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"screen\" rel=\"stylesheet\" />\n<link href=\"/stylesheets/too_big_stylesheet_split3.css\" media=\"screen\" rel=\"stylesheet\" />\n<![endif]-->", output
+      assert_equal "<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet.css\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split2.css\" />\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split3.css\" />\n<![endif]-->", output
     end
 
     class RailsEnvDefault < ActionView::TestCase
@@ -29,16 +29,16 @@ module CssSplitter
 
       test "should default to false on splits" do
         output = split_stylesheet_link_tag("too_big_stylesheet")
-        assert_equal "<link href=\"/stylesheets/too_big_stylesheet.css\" media=\"screen\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link debug=\"false\" href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"screen\" rel=\"stylesheet\" />\n<![endif]-->", output
+        assert_equal "<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet.css\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split2.css\" debug=\"false\" />\n<![endif]-->", output
       end
 
       test "should respect the debug=true option" do
         output = split_stylesheet_link_tag("too_big_stylesheet", debug: true)
-        assert_equal "<link debug=\"true\" href=\"/stylesheets/too_big_stylesheet.css\" media=\"screen\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link debug=\"true\" href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"screen\" rel=\"stylesheet\" />\n<![endif]-->", output
+        assert_equal "<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet.css\" debug=\"true\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split2.css\" debug=\"true\" />\n<![endif]-->", output
       end
       test "should respect the debug=false option" do
         output = split_stylesheet_link_tag("too_big_stylesheet", debug: false)
-        assert_equal "<link debug=\"false\" href=\"/stylesheets/too_big_stylesheet.css\" media=\"screen\" rel=\"stylesheet\" />\n<!--[if lte IE 9]>\n<link debug=\"false\" href=\"/stylesheets/too_big_stylesheet_split2.css\" media=\"screen\" rel=\"stylesheet\" />\n<![endif]-->", output
+        assert_equal "<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet.css\" debug=\"false\" />\n<!--[if lte IE 9]>\n<link rel=\"stylesheet\" media=\"screen\" href=\"/stylesheets/too_big_stylesheet_split2.css\" debug=\"false\" />\n<![endif]-->", output
       end
     end
   end


### PR DESCRIPTION
Maybe it's a good idea to lock Rails version in the Gemfile to prevent false failures like this in the future?