### PR TITLE
Fix regex comparison for media queries

### DIFF
--- a/lib/css_splitter/splitter.rb
+++ b/lib/css_splitter/splitter.rb
@@ -18,7 +18,7 @@ module CssSplitter
       in_media_query = false
 
       partial_rules.each do |rule|
-        if rule =~ /^@media/
+        if rule =~ /^\s*@media/
           in_media_query = true
         elsif bracket_balance == 0
           in_media_query = false

--- a/test/unit/splitter_test.rb
+++ b/test/unit/splitter_test.rb
@@ -40,6 +40,11 @@ class CssSplitterTest < ActiveSupport::TestCase
     assert_equal ["a{foo:bar;}", "@media print{b{baz:qux;}", "c{quux:corge;}", "}", "d{grault:garply;}"], CssSplitter::Splitter.split_string_into_rules(has_media)
   end
 
+  test '#split_string_into_rules containing media queries with leading whitespace' do
+    has_media = "a{foo:bar;}\n  @media print{b{baz:qux;}c{quux:corge;}}d{grault:garply;}"
+    assert_equal ["a{foo:bar;}", "\n  @media print{b{baz:qux;}", "c{quux:corge;}", "}", "d{grault:garply;}"], CssSplitter::Splitter.split_string_into_rules(has_media)
+  end
+
   test "#split_string_into_rules containing keyframes" do
     has_keyframes = "a{foo:bar;}@keyframes rubes{from{baz:qux;}50%{quux:corge;}}d{grault:garply;}"
     assert_equal ["a{foo:bar;}", "@keyframes rubes{from{baz:qux;}50%{quux:corge;}}", "d{grault:garply;}"], CssSplitter::Splitter.split_string_into_rules(has_keyframes)


### PR DESCRIPTION
Hi, I wanna let you know that the gem wasn't working when there was a whitespace character before the @media rule so I change it.

