### PR TITLE
travis uses recent ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: false
 language: ruby
 bundler_args: --without development
 rvm:
   - "1.9.3"
-  - "2.1.1"
+  - "2.2"


### PR DESCRIPTION
Also use travis containers
(it is quicker / uses less resources)