### PR TITLE
Gracefully handle when assets are not configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ bundler_args: --without development
 rvm:
   - "1.9.3"
   - "2.1.1"
+before_install:
+  - gem update bundler

--- a/lib/css_splitter/engine.rb
+++ b/lib/css_splitter/engine.rb
@@ -3,7 +3,9 @@ module CssSplitter
     isolate_namespace CssSplitter
 
     initializer 'css_splitter.sprockets_engine', after: 'sprockets.environment', group: :all do |app|
-      app.assets.register_bundle_processor 'text/css', CssSplitter::SprocketsEngine
+      app.config.assets.configure do |assets|
+        assets.register_bundle_processor 'text/css', CssSplitter::SprocketsEngine
+      end
     end
 
     initializer 'css_splitter.action_controller' do |app|


### PR DESCRIPTION
In sprockets-rails v3, app.assets is now only set when assets.compile is
set to true.  This is currently causing an error when upgrading to Rails
4.2.5.

This change will cause CSS Splitter to only be registered when assets
themselves are configured.

Fixes #60