### PR TITLE
Explicitly configure assets in test

### DIFF
--- a/lib/css_splitter/engine.rb
+++ b/lib/css_splitter/engine.rb
@@ -3,8 +3,10 @@ module CssSplitter
     isolate_namespace CssSplitter
 
     initializer 'css_splitter.sprockets_engine', after: 'sprockets.environment', group: :all do |app|
-      app.config.assets.configure do |assets|
-        assets.register_bundle_processor 'text/css', CssSplitter::SprocketsEngine
+      if app.config.assets
+        app.config.assets.configure do |assets|
+          assets.register_bundle_processor 'text/css', CssSplitter::SprocketsEngine
+        end
       end
     end
 

--- a/test/css_splitter_test.rb
+++ b/test/css_splitter_test.rb
@@ -35,7 +35,9 @@ class CssSplitterTest < ActiveSupport::TestCase
   end
 
   def assets
-    Rails.application.assets
+    Sprockets::Environment.new(Rails.root).tap do |assets|
+      assets.append_path Rails.root.join("app/assets/stylesheets")
+      assets.css_compressor = :sass
+    end
   end
-
 end


### PR DESCRIPTION
The fix works for versions of sprockets before and after 3.0.

Unfortunately, I can't figure out how to configuring `assets` properly for the test environment. So the tests are failing.

If I peg sprockets: `gem "sprockets", "< 3.0"`, the tests will pass, but not able to configure the assets properly so it will work. Was hoping to manually configure sprockets so the tests will work in all versions of sprockets.

I think in test, sprockets are turned off by default. Or at least the compression is turned off by default.

Any pointers would be great.

Thanks

/cc @matthewd any pointers would be helpful