### PR TITLE
Remove isolate_namespace to fix unresolved split_stylesheet_link_tag

### DIFF
--- a/lib/css_splitter/engine.rb
+++ b/lib/css_splitter/engine.rb
@@ -1,7 +1,5 @@
 module CssSplitter
   class Engine < ::Rails::Engine
-    isolate_namespace CssSplitter
-
     initializer 'css_splitter.sprockets_engine', after: 'sprockets.environment', group: :all do |app|
       app.config.assets.configure do |assets|
         assets.register_bundle_processor 'text/css', CssSplitter::SprocketsEngine


### PR DESCRIPTION
I added what seemed to be a completely unrelated gem and began getting undefined method `split_stylesheet_link_tag' as described in https://github.com/zweilove/css_splitter/pull/45.  I tried the fix recommended in the comments of removing the isolate_namespace and that resolved things for me.

I'm not sure what caused it in my case but I noticed that before including the unrelated gem, css_splitter would get included as a helper before my local helpers.  After including the unrelated gem, it would get included after but it wouldn't be in my ancestor chain when loading the view.  Thats as far as I got trying to figure out what was going on.