### PR TITLE
Follow sproket engine interface guidelines

### DIFF
--- a/lib/css_splitter/sprockets_engine.rb
+++ b/lib/css_splitter/sprockets_engine.rb
@@ -11,12 +11,19 @@ module CssSplitter
     end
 
     def self.call(input)
-      filename = input[:filename]
-      data     = input[:data]
-      context  = input[:environment].context_class.new(input)
+      data_in = input[:data]
 
-      data = self.new(filename) { data }.render(context, {})
-      context.metadata.merge(data: data.to_str)
+      # Instantiate Sprockets::Context to pass along helper methods for Tilt
+      # processors
+      context = input[:environment].context_class.new(input)
+
+      # Pass the asset file contents as a block to the template engine,
+      # then get the results of the engine rendering
+      engine = self.new { data_in }
+      rendered_data = engine.render(context, {})
+
+      # Return the data and any metadata (ie file dependencies, etc)
+      context.metadata.merge(data: rendered_data.to_str)
     end
 
     def evaluate(scope, locals, &block)

--- a/lib/css_splitter/sprockets_engine.rb
+++ b/lib/css_splitter/sprockets_engine.rb
@@ -10,6 +10,15 @@ module CssSplitter
     def prepare
     end
 
+    def self.call(input)
+      filename = input[:filename]
+      data     = input[:data]
+      context  = input[:environment].context_class.new(input)
+
+      data = self.new(filename) { data }.render(context, {})
+      context.metadata.merge(data: data.to_str)
+    end
+
     def evaluate(scope, locals, &block)
       # Evaluate the split if the asset is named with a trailing _split2, _split3, etc.
       if scope.logical_path =~ /_split(\d+)$/


### PR DESCRIPTION
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors

`new.render` on Sprokets engines is deprecated as of Sprokets v3.7.0 (its currently called through the `Sprockets::LegacyTiltProcessor` class - see `sprockets-3.7.0/lib/sprockets/legacy_tilt_processor.rb:20`).

This PR implement the class method `call` which instantiates a `CssSplitter::SproketEngine` and calls `render`.